### PR TITLE
Make UI Mobile Friendly

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <div class="controls">
-    <div class="field has-addons">
+    <div class="field has-addons control-buttons">
         <p class="control">
             <button class="button" data-action="start" title="Start">
             <span class="icon has-text-success">

--- a/src/index.html
+++ b/src/index.html
@@ -62,6 +62,51 @@
             </div>
         </div>
     </div>
+    <div class="mobile-metadata-toggle">
+        <p class="control">
+            <span id="mobile-metadata-toggle" tabindex="0" class="button">
+                <span class="icon has-text-link">
+                    <span class="mdi mdi-24px mdi-cog" />
+                </span>
+            </span>
+        </p>
+    </div>
+    <div id="mobile-metadata-controls">
+        <div class="mobile-control">
+            <span class="mobile-control-label">Mode</span>
+            <ul class="radio-buttons">
+                <li>
+                    <input type="radio" name="mode" id="mode-dev" value="DEV" class="sends-mutate-request" checked>
+                    <label for="mode-dev">Development</label>
+                </li>
+                <li>
+                    <input type="radio" name="mode" id="mode-comp" value="COMP" class="sends-mutate-request">
+                    <label for="mode-comp">Competition</label>
+                </li>
+            </ul>
+        </div>
+        <div class="mobile-control">
+            <span class="mobile-control-label" style="margin-right: 0.85rem;">Zone</span>
+            <ul class="radio-buttons">
+                <li class="compact">
+                    <input type="radio" name="zone" id="zone-0" value="0" class="sends-mutate-request" checked>
+                    <label for="zone-0">0</label>
+                </li>
+                <li class="compact">
+                    <input type="radio" name="zone" id="zone-1" value="1" class="sends-mutate-request">
+                    <label for="zone-1">1</label>
+                </li>
+                <li class="compact">
+                    <input type="radio" name="zone" id="zone-2" value="2" class="sends-mutate-request">
+                    <label for="zone-2">2</label>
+                </li>
+                <li class="compact">
+                    <input type="radio" name="zone" id="zone-3" value="3" class="sends-mutate-request">
+                    <label for="zone-3">3</label>
+                </li>
+            </ul>
+    </div>
+    </div>
 </div>
 <table class="log-table table is-striped is-narrow is-hoverable is-fullwidth is-family-monospace">
     <tbody id="log"></tbody>

--- a/src/main.js
+++ b/src/main.js
@@ -161,7 +161,14 @@ const handlers = {
 
 const ack = {
   kill: (payload) => {
-    createPlainLogEntry("💀 Killed", "text-d-red", "text-bold");
+    const logEntry = createPlainLogEntry(
+      "💀 Killed",
+      "text-d-red",
+      "text-bold"
+    );
+    if (shouldAutoScroll) {
+      logEntry.scrollIntoView();
+    }
   },
   restart: (payload) => {
     createPlainLogEntry("🔄 Restart", "text-d-blue", "text-bold");
@@ -196,6 +203,7 @@ function createPlainLogEntry(text, ...classes) {
   entryContentElement.setAttribute("colspan", 2);
   entry.appendChild(entryContentElement);
   $.log.appendChild(entry);
+  return entry;
 }
 
 function sendProcessRequest(type) {

--- a/src/main.js
+++ b/src/main.js
@@ -77,6 +77,15 @@ window.addEventListener("DOMContentLoaded", (event) => {
       sendMutateRequest(e.target.dataset.property, e.target.value);
     })
   );
+
+  document.querySelectorAll("#mobile-metadata-toggle").forEach((el) =>
+    el.addEventListener("click", function (e) {
+      e.preventDefault();
+      document
+        .getElementById("mobile-metadata-controls")
+        .classList.toggle("is-active");
+    })
+  );
 });
 
 const status_labels = {

--- a/src/style.scss
+++ b/src/style.scss
@@ -22,11 +22,20 @@ body {
   width: 100%;
   top:0;
 
+  .mobile-metadata-toggle {
+    display: none;
+  }
+
+  #mobile-metadata-controls {
+    display: none;
+  }
+
   @media screen and (max-width: $mobile-breakpoint) {
     bottom: 0;
     top: initial;
     position: fixed;
     flex-direction: row-reverse;
+    flex-wrap: wrap-reverse;
 
     .control-buttons {
         flex-direction: row-reverse;
@@ -37,10 +46,80 @@ body {
       justify-content: flex-end;
     }
 
+    .mobile-metadata-toggle {
+      display: flex;
+      flex-basis: 100%;
+      height: 0;
+    }
+
+    #mobile-metadata-controls{
+      &.is-active {
+        display: flex;
+        padding-bottom: 0.5rem;
+        flex-direction: column;
+      }
+    }
+
+    .mobile-control {
+      display: flex;
+      align-items: center;
+
+      .mobile-control-label {
+        font-weight: bold;
+        margin-right: 0.5rem;
+        &:after {
+          content: ":";
+        }
+      }
+    }
   }
 
   & > .field {
     margin-bottom: 0;
+  }
+
+  .radio-buttons {
+    list-style-type: none;
+
+    & li {
+      float: left;
+      width: 128px;
+      height: 2rem;
+      position: relative;
+      margin-right: 0;
+      padding-right: 0;
+    }
+
+    & li.compact {
+      width: 64px;
+    }
+
+    & label,input{
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
+
+    & input[type="radio"] {
+      opacity: 0;
+      z-index: 1;
+      cursor: pointer;
+    }
+
+    & input[type="radio"]:checked + label {
+      background-color: $primary;
+      color: $white;
+    }
+
+    & label {
+      background-color: $white;
+      color: $dark;
+      text-align: center;
+      line-height: 2rem;
+    }
   }
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -12,13 +12,6 @@ body {
     // justify-content: space-between; // Uncomment to scroll from top of screen down
     min-height: 100vh;
   }
-
-  // In the rendered DOM there is an empty div with the inline style
-  // "position: static !important;" at the end of the body.
-  // This workaround stops it interfering with the flexbox layout.
-  > div:last-of-type {
-    display: none;
-  }
 }
 
 .controls {

--- a/src/style.scss
+++ b/src/style.scss
@@ -9,7 +9,6 @@ body {
   @media screen and (max-width: $mobile-breakpoint) {
     display: flex;
     flex-direction: column-reverse;
-    // justify-content: space-between; // Uncomment to scroll from top of screen down
     min-height: 100vh;
   }
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -34,6 +34,17 @@ body {
     bottom: 0;
     top: initial;
     position: fixed;
+    flex-direction: row-reverse;
+
+    .control-buttons {
+        flex-direction: row-reverse;
+    }
+
+    #status {
+      display: flex;
+      justify-content: flex-end;
+    }
+
   }
 
   & > .field {

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,8 +1,25 @@
 $primary: #3270ed;
 $family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", "Cantarell", "Ubuntu", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 $navbar-breakpoint: 1px;
+$mobile-breakpoint: 640px;
 
 @import "node_modules/bulma/bulma";
+
+body {
+  @media screen and (max-width: $mobile-breakpoint) {
+    display: flex;
+    flex-direction: column-reverse;
+    // justify-content: space-between; // Uncomment to scroll from top of screen down
+    min-height: 100vh;
+  }
+
+  // In the rendered DOM there is an empty div with the inline style
+  // "position: static !important;" at the end of the body.
+  // This workaround stops it interfering with the flexbox layout.
+  > div:last-of-type {
+    display: none;
+  }
+}
 
 .controls {
   display: flex;
@@ -13,14 +30,34 @@ $navbar-breakpoint: 1px;
   width: 100%;
   top:0;
 
+  @media screen and (max-width: $mobile-breakpoint) {
+    bottom: 0;
+    top: initial;
+    position: fixed;
+  }
+
   & > .field {
     margin-bottom: 0;
   }
 }
 
+.metadata-selectors {
+ @media screen and (max-width: $mobile-breakpoint) {
+    display: none !important; // Override Bulma .field.is-grouped
+  }
+  display: initial;
+}
+
 .log-table{
   // button height + (4px padding * 2) + (1px border * 2)
-  margin-top: calc(2.5em + 8px + 2px);
+  $controls-height: calc(2.5em + 8px + 2px);
+  margin-top: $controls-height;
+  margin-bottom: 0 !important; // Override Bulma .table:not(:last-child)
+
+  @media screen and (max-width: $mobile-breakpoint) {
+    margin-bottom: $controls-height !important; // Override Bulma .table:not(:last-child)
+    margin-top: 0;
+  }
 }
 
 #status {


### PR DESCRIPTION
This moves the control bar to bottom of the screen for mobile users (this is easier to tap with thumbs when holding a device).

![image](https://user-images.githubusercontent.com/1496834/192893862-b8d99041-d93e-46f5-905d-89a64b02d71b.png)


## TODO
 - [x] Add back metadata controls with mobile friendly UI
 - [x] Decide on logs scrolling in from the top or bottom of the screen (currently scrolls up from the bottom)