### PR TITLE
Add .git-blame-ignore-revs and instructions

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Run prettier on main.js
+6694577018367b094b7806ebd37b9cc507d460ac

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ A browser based interface for [Astoria](https://github.com/srobo/astoria) based 
 
 Run `npm install`
 
+Run `git config blame.ignorerevsfile .git-blame-ignore-revs` to get a better experience using git blame.
+
 ### Development
 
 Run `npm start` to start the development server. You will then be able to navigate to [http://localhost:1234](http://localhost:1234) to see the UI.


### PR DESCRIPTION
By using this file we can tell git blame to ignore any commits we want. I have set it up to ignore the reformatting commit to provide better blame on lines that were touched.

Having done a quick google it seems that .git-blame-ignore-revs is what projects seem to be standardising on, so this could work out the box if people have configured their git globally already.