### PR TITLE
Visually center plain log messages (e.g. Restart, Stop)

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -326,7 +326,7 @@ body {
   .plain-log-entry {
     text-align: center;
     font-family: $family-sans-serif;
-    grid-column: 1 / 3;
+    grid-column: 2 / 3;
   }
 }
 


### PR DESCRIPTION
"Plain logs" (those we add ourselves as opposed to those we recieve over MQTT) are now visually centered
![image](https://github.com/srobo/kit-ui/assets/1496834/41ad593c-5eb7-4b54-8f9f-42c6a4202f41)

Closes #246 
